### PR TITLE
lw350: use upd765 emulation

### DIFF
--- a/src/devices/machine/upd765.cpp
+++ b/src/devices/machine/upd765.cpp
@@ -20,7 +20,7 @@
 #define LOG_LIVE    (1U << 12)  // Live states
 #define LOG_DONE    (1U << 13)  // Command done
 
-#define VERBOSE (LOG_GENERAL | LOG_WARN )
+#define VERBOSE (LOG_GENERAL | LOG_WARN)
 
 #include "logmacro.h"
 
@@ -57,6 +57,7 @@ DEFINE_DEVICE_TYPE(PC8477B,        pc8477b_device,        "pc8477b",        "Nat
 DEFINE_DEVICE_TYPE(WD37C65C,       wd37c65c_device,       "wd37c65c",       "Western Digital WD37C65C FDC")
 DEFINE_DEVICE_TYPE(MCS3201,        mcs3201_device,        "mcs3201",        "Motorola MCS3201 FDC")
 DEFINE_DEVICE_TYPE(TC8566AF,       tc8566af_device,       "tc8566af",       "Toshiba TC8566AF FDC")
+DEFINE_DEVICE_TYPE(HD63266F,       hd63266f_device,       "hd63266f",       "Hitachi HD63266F FDC")
 
 void upd765a_device::map(address_map &map)
 {
@@ -3293,3 +3294,161 @@ void upd72067_device::auxcmd_w(uint8_t data)
 		break;
 	}
 }
+
+
+hd63266f_device::hd63266f_device(const machine_config& mconfig, const char* tag, device_t* owner, uint32_t clock)
+: upd765_family_device(mconfig, HD63266F, tag, owner, clock)
+, inp_cb(*this)
+{
+	has_dor = false;
+}
+
+void hd63266f_device::device_start()
+{
+	upd765_family_device::device_start();
+	inp_cb.resolve();
+}
+
+void hd63266f_device::map(address_map& map)
+{
+	map(0x0, 0x0).rw(FUNC(upd765a_device::msr_r), FUNC(hd63266f_device::abort_w));
+	map(0x1, 0x1).rw(FUNC(upd765a_device::fifo_r), FUNC(upd765a_device::fifo_w));
+	map(0x2, 0x2).r(FUNC(hd63266f_device::extstat_r));
+}
+
+void hd63266f_device::soft_reset()
+{
+	upd765_family_device::soft_reset();
+	delayed_command = 0;
+	motor_state = 0;
+	for(int i = 0; i < 4; i++)
+		if(flopi[i].dev) flopi[i].dev->mon_w(1);
+}
+
+void hd63266f_device::abort_w(u8 data)
+{
+	if(data == 0xff) {
+		soft_reset();
+		LOGCOMMAND("abort\n");
+	}
+}
+
+int hd63266f_device::check_command()
+{
+	switch(command[0] & 0x1f) {
+		case 0x0e:
+			return C_SLEEP;
+	}
+	return upd765_family_device::check_command();
+}
+
+void hd63266f_device::execute_command(int cmd)
+{
+	switch(cmd)
+	{
+		case C_SLEEP:
+			for(int i = 0; i < 4; i++)
+				if(flopi[i].dev) flopi[i].dev->mon_w(1);
+			main_phase = PHASE_CMD;
+			motor_state = 0;
+			LOGCOMMAND("sleep\n");
+			break;
+		case C_SENSE_DRIVE_STATUS:
+			upd765_family_device::execute_command(cmd);
+			if(inp_cb)
+				result[0] = (result[0] & ~ST3_TS) | (inp_cb() ? 0 : 8);
+			break;
+		default:
+			upd765_family_device::execute_command(cmd);
+			break;
+	}
+}
+
+u8 hd63266f_device::extstat_r()
+{
+	return (irq << 6) | motor_state;
+}
+
+// no documentation for motor control so borrow some of 82072
+void hd63266f_device::start_command(int cmd)
+{
+	// check if the command specifies a target drive
+	switch(cmd) {
+	case C_READ_TRACK:
+	case C_WRITE_DATA:
+	case C_READ_DATA:
+	case C_RECALIBRATE:
+	//case C_WRITE_DELETED_DATA:
+	case C_READ_ID:
+	//case C_READ_DELETED_DATA:
+	case C_FORMAT_TRACK:
+	case C_SEEK:
+		// start the motor
+		motor_control(command[1] & 0x3, true);
+		break;
+	default:
+		motor_on_counter = 0;
+		break;
+	}
+
+	// execute the command immediately if there's no motor on delay
+	if(motor_on_counter == 0) {
+		upd765_family_device::start_command(cmd);
+	} else
+		delayed_command = cmd;
+}
+
+void hd63266f_device::motor_control(int fid, bool start_motor)
+{
+	floppy_info &fi = flopi[fid];
+
+	if(start_motor) {
+		// if we are selecting a different drive, stop the motor on the previously selected drive
+		if(selected_drive != fid && flopi[selected_drive].dev && flopi[selected_drive].dev->mon_r() == 0)
+			flopi[selected_drive].dev->mon_w(1);
+
+		// start the motor on the selected drive
+		if(fi.dev && fi.dev->mon_r() == 1) {
+			LOGCOMMAND("motor_control: switching on motor for drive %d\n", fid);
+
+			// select the drive and enable the motor
+			set_ds(fid);
+			fi.dev->mon_w(0);
+			motor_on_counter = 3;
+			motor_state |= 1 << fid;
+		}
+	} else {
+		// motor off timer only applies to the selected drive
+		if(selected_drive != fid)
+			return;
+
+		logerror("motor_on_counter %d\n", motor_on_counter);
+		// decrement motor on counter
+		if(motor_on_counter)
+			motor_on_counter--;
+
+		// execute the command if the motor on counter has expired
+		if(motor_on_counter == 0 && main_phase == PHASE_CMD && delayed_command) {
+			upd765_family_device::start_command(delayed_command);
+
+			delayed_command = 0;
+
+			return;
+		}
+	}
+}
+
+void hd63266f_device::index_callback(floppy_image_device *floppy, int state)
+{
+	if(state)
+		for(floppy_info &fi : flopi) {
+			if(fi.dev != floppy)
+				continue;
+
+			// update motor on/off counters and stop motor if necessary
+			motor_control(fi.id, false);
+		}
+
+	upd765_family_device::index_callback(floppy, state);
+}
+

--- a/src/devices/machine/upd765.h
+++ b/src/devices/machine/upd765.h
@@ -280,6 +280,8 @@ protected:
 		C_SCAN_HIGH,
 		C_MOTOR_ONOFF,
 		C_VERSION,
+		C_SLEEP,
+		C_ABORT,
 
 		C_INVALID,
 		C_INCOMPLETE
@@ -591,6 +593,32 @@ private:
 	uint8_t m_cr1;
 };
 
+class hd63266f_device : public upd765_family_device {
+public:
+	hd63266f_device(const machine_config& mconfig, const char* tag, device_t* owner, uint32_t clock);
+
+	virtual void map(address_map& map) override;
+	auto inp_rd_callback() { return inp_cb.bind(); } // this is really the ts signal
+
+	void rate_w(u8 state) { state ? set_rate(500000) : set_rate(250000); }
+	void abort_w(u8 data);
+	u8 extstat_r();
+protected:
+	virtual void soft_reset() override;
+	virtual void device_start() override;
+private:
+	virtual int check_command() override;
+	virtual void execute_command(int cmd) override;
+	virtual void start_command(int cmd) override;
+	void motor_control(int fid, bool start_motor);
+	virtual void index_callback(floppy_image_device *floppy, int state) override;
+
+	u8 motor_on_counter;
+	int delayed_command;
+	u8 motor_state;
+	devcb_read_line inp_cb;
+};
+
 DECLARE_DEVICE_TYPE(UPD765A,        upd765a_device)
 DECLARE_DEVICE_TYPE(UPD765B,        upd765b_device)
 DECLARE_DEVICE_TYPE(I8272A,         i8272a_device)
@@ -607,5 +635,6 @@ DECLARE_DEVICE_TYPE(PC8477B,        pc8477b_device)
 DECLARE_DEVICE_TYPE(WD37C65C,       wd37c65c_device)
 DECLARE_DEVICE_TYPE(MCS3201,        mcs3201_device)
 DECLARE_DEVICE_TYPE(TC8566AF,       tc8566af_device)
+DECLARE_DEVICE_TYPE(HD63266F,       hd63266f_device)
 
 #endif // MAME_DEVICES_MACHINE_UPD765_H

--- a/src/mame/brother/lw350.cpp
+++ b/src/mame/brother/lw350.cpp
@@ -76,792 +76,8 @@ see https://github.com/BartmanAbyss/brother-hardware/tree/master/2G%20-%20Brothe
 
 ***************************************************************************/
 
-// UPD765 interface not working
-//#define UPD765
-
-#ifndef UPD765
-
-class lw350_floppy_image_device;
-
-class lw350_floppy_connector : public device_t, public device_slot_interface
-{
-public:
-	lw350_floppy_connector(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
-
-	lw350_floppy_image_device *get_device();
-
-protected:
-	void device_start() override {}
-	void device_config_complete() override {}
-};
-
-class lw350_floppy_image_device : public device_t, public device_image_interface
-{
-public:
-	lw350_floppy_image_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
-
-public:
-	bool is_readable()  const noexcept override { return true; }
-	bool is_writeable() const noexcept override { return true; }
-	bool is_creatable() const noexcept override { return true; }
-	bool is_reset_on_load() const noexcept override { return false; }
-	const char* image_type_name() const noexcept override { return "floppydisk"; }
-	const char* image_brief_type_name() const noexcept override { return "flop"; }
-	const char *file_extensions() const noexcept override { return "img"; }
-	const char *image_interface() const noexcept override { return "lw350_floppy_35"; }
-	image_init_result call_load() override;
-	void call_unload() override;
-
-	bool loaded = false;
-	bool dirty = false;
-	std::unique_ptr<uint8_t[]> image;
-	uint32_t image_length{};
-
-protected:
-	void device_start() override {}
-};
-
-DEFINE_DEVICE_TYPE(LW350_FLOPPY_CONNECTOR, lw350_floppy_connector, "lw350_floppy_connector", "LW350 Floppy drive connector abstraction")
-DEFINE_DEVICE_TYPE(LW350_FLOPPY, lw350_floppy_image_device, "lw350_floppy_35", "LW350 3.5\" floppy drive")
-
-lw350_floppy_connector::lw350_floppy_connector(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock) :
-	device_t(mconfig, LW350_FLOPPY_CONNECTOR, tag, owner, clock),
-	device_slot_interface(mconfig, *this)
-{
-}
-
-lw350_floppy_image_device *lw350_floppy_connector::get_device()
-{
-	return dynamic_cast<lw350_floppy_image_device *>(get_card_device());
-}
-
-lw350_floppy_image_device::lw350_floppy_image_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: device_t(mconfig, LW350_FLOPPY, tag, owner, clock),
-	device_image_interface(mconfig, *this)
-{
-}
-
-image_init_result lw350_floppy_image_device::call_load()
-{
-	// copy image into our buffer
-	auto l = length();
-	fread(image, l);
-	image_length = l;
-
-	loaded = true;
-	return image_init_result::PASS;
-}
-
-void lw350_floppy_image_device::call_unload()
-{
-	if(dirty && !is_readonly()) {
-		if(reopen_for_write(filename()) == std::error_condition())
-			fwrite(image.get(), image_length);
-	}
-
-	loaded = false;
-}
-
-// FDC high-level emulation (not timing accurate) based on "Hitachi 8-Bit Microcomputer HD63265 FDC Floppy Disk Controller User's Manual"
-// https://archive.org/details/bitsavers_hitachidatDiskControllerUsersManual2edMar89_3858532
-
-class hd63266f_device_t : public device_t {
-public:
-	hd63266f_device_t(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock);
-
-	auto irq_wr_cb() { return irq_cb.bind(); }
-	auto dreq_wr_cb() { return dreq_cb.bind(); }
-	auto dend_rd_cb() { return dend_cb.bind(); }
-
-	void set_floppy(lw350_floppy_image_device* floppy) { this->floppy = floppy; }
-
-	void reset();
-	void write(uint8_t data);
-	uint8_t read();
-	void execute();
-	void abort();
-
-	uint8_t status_r() { return str; }
-	void abort_w(uint8_t data) { if(data == 0xff) abort(); else logerror("fdc:abort_w %02x is ignored %s\n", data, machine().describe_context()); }
-	void data_w(uint8_t data) { write(data); }
-	uint8_t data_r() { return read(); }
-
-protected:
-	uint8_t str; // status register
-	uint8_t dtr; // data register
-	uint8_t cmd; // current command
-	uint8_t parameter_cnt;
-	uint16_t dma_cnt; // active DMA transfer; number of bytes left
-	off_t dma_src; // current offset in floppy image for DMA transfer
-
-	// command parameters
-	uint8_t hsl_us; // Head Select-Unit Select
-	uint8_t ca; // Cylinder Address (0-255)
-	uint8_t ha; // Head Address (0-1)
-	uint8_t sa; // Sector Address (1-255)
-	uint8_t rl; // Record Length (0-6) (p. 20)
-	uint8_t esn; // End Sector Number (1-255; compare: 1-253)
-	uint8_t gsl; // Gap Skip Length
-	uint8_t mnl; // Meaning Length
-
-	// WRITE FORMAT
-	uint8_t scnt; // Sector Count (1-255)
-	uint8_t gp3l; // Gap 3 Length (1-255)
-	uint8_t dud; // Dummy Data (0-255)
-
-	// SEEK
-	uint8_t ncn; // New Cylinder Number (0-255)
-
-	// COMPARE
-	uint8_t step; // Step (p. 23)
-
-	// SPECIFY 1
-	uint8_t str_hdut; // Stepping Rate-Head Unload Time (p. 23)
-	uint8_t hdlt_ndm; // Head Load-Time-Non-DMA Mode (p. 25)
-
-	// SPECIFY 2
-	uint8_t lctk; // Low Current Track
-	uint8_t pc1_pc0; // Precompensation Delay 1, 0
-	uint8_t pcdct; // Precompensation Delay Change Track
-
-	// result parameters
-	uint8_t ssb0, ssb1, ssb2, ssb3; // (p. 28ff)
-	uint8_t pcn; // physical cylinder number
-
-	devcb_write_line irq_cb, dreq_cb;
-	devcb_read_line dend_cb;
-
-	void device_start() override;
-
-	lw350_floppy_image_device *floppy;
-};
-
-DEFINE_DEVICE_TYPE(HD63266F, hd63266f_device_t, "hd63266f", "HD63266F")
-
-enum FDC_STATUS_MASK : uint8_t
-{
-	FDC_STATUSM_D0S = 0x1,
-	FDC_STATUSM_D1S = 0x2,
-	FDC_STATUSM_D2S = 0x4,
-	FDC_STATUSM_D3S = 0x8,
-	FDC_STATUSM_BSY = 0x10,
-	FDC_STATUSM_NDM = 0x20,
-	FDC_STATUSM_DIR = 0x40,
-	FDC_STATUSM_TXR = 0x80,
-};
-
-enum FDC_STATUS_BITS : uint8_t
-{
-	FDC_STATUSB_D0S = 0x0,
-	FDC_STATUSB_D1S = 0x1,
-	FDC_STATUSB_D2S = 0x2,
-	FDC_STATUSB_D3S = 0x3,
-	FDC_STATUSB_BSY = 0x4,
-	FDC_STATUSB_NDM = 0x5,
-	FDC_STATUSB_DIR = 0x6,
-	FDC_STATUSB_TXR = 0x7,
-};
-
-enum FDC_COMMAND : uint8_t
-{
-	FDC_COMMAND_READ_ERRONEOUS_DATA = 0x2,
-	FDC_COMMAND_SPECIFY_1 = 0x3,
-	FDC_COMMAND_CHECK_DEVICE_STATUS = 0x4,
-	FDC_COMMAND_WRITE_DATA = 0x5,
-	FDC_COMMAND_READ_DATA = 0x6,
-	FDC_COMMAND_RECALIBRATE = 0x7,
-	FDC_COMMAND_CHECK_INTERRUPT_STATUS = 0x8,
-	FDC_COMMAND_WRITE_DELETED_DATA = 0x9,
-	FDC_COMMAND_READ_ID = 0xA,
-	FDC_COMMAND_SPECIFY_2 = 0xB,
-	FDC_COMMAND_READ_DELETED_DATA = 0xC,
-	FDC_COMMAND_WRITE_FORMAT = 0xD,
-	FDC_COMMAND_SLEEP = 0xE,
-	FDC_COMMAND_SEEK = 0xF,
-	FDC_COMMAND_COMPARE_EQUAL = 0x11,
-	FDC_COMMAND_READ_LONG = 0x12,
-	FDC_COMMAND_WRITE_LONG = 0x16,
-	FDC_COMMAND_COMPARE_LOW_OR_EQUAL = 0x19,
-	FDC_COMMAND_COMPARE_HIGH_OR_EQUAL = 0x1D,
-	FDC_COMMAND_ABORT = 0x1F,
-	FDC_COMMAND_SKIP_DDAM = 0x20,
-	FDC_COMMAND_MODE_FM = 0x0,
-	FDC_COMMAND_MODE_MFM = 0x40,
-	FDC_COMMAND_MULTI_TRACK = 0x80,
-};
-
-enum FDC_SSB3_MASK : uint8_t
-{
-	FDC_SSB3M_US0 = 0x1,
-	FDC_SSB3M_US1 = 0x2,
-	FDC_SSB3M_HSL = 0x4,
-	FDC_SSB3M_DSD = 0x8,
-	FDC_SSB3M_TRZ = 0x10,
-	FDC_SSB3M_RDY = 0x20,
-	FDC_SSB3M_WPT = 0x40,
-	FDC_SSB3M_FLT = 0x80,
-};
-
-enum FDC_SSB3_BITS : uint8_t
-{
-	FDC_SSB3B_US0 = 0x0,
-	FDC_SSB3B_US1 = 0x1,
-	FDC_SSB3B_HSL = 0x2,
-	FDC_SSB3B_DSD = 0x3,
-	FDC_SSB3B_TRZ = 0x4,
-	FDC_SSB3B_RDY = 0x5,
-	FDC_SSB3B_WPT = 0x6,
-	FDC_SSB3B_FLT = 0x7,
-};
-
-enum FDC_SSB0_BITS
-{
-	FDC_SSB0B_US0 = 0x0,
-	FDC_SSB0B_US1 = 0x1,
-	FDC_SSB0B_HSL = 0x2,
-	FDC_SSB0B_DNR = 0x3,
-	FDC_SSB0B_DER = 0x4,
-	FDC_SSB0B_SED = 0x5,
-};
-
-enum FDC_SSB0_MASK : uint8_t
-{
-	FDC_SSB0M_US0 = 0x1,
-	FDC_SSB0M_US1 = 0x2,
-	FDC_SSB0M_HSL = 0x4,
-	FDC_SSB0M_DNR = 0x8, // drive not ready
-	FDC_SSB0M_DER = 0x10,
-	FDC_SSB0M_SED = 0x20, // seek end
-	FDC_SSB0M_INC_NOR = 0x0,
-	FDC_SSB0M_INC_ABE = 0x40,
-	FDC_SSB0M_INC_IVC = 0x80,
-	FDC_SSB0M_INC_CDS = 0xC0,
-};
-
-enum FDC_SSB1_BITS
-{
-	FDC_SSB1B_ANF = 0x0,
-	FDC_SSB1B_WPM = 0x1,
-	FDC_SSB1B_INF = 0x2,
-	FDC_SSB1B_DOR = 0x4,
-	FDC_SSB1B_CER = 0x5,
-	FDC_SSB1B_NDE = 0x7,
-};
-
-enum FDC_SSB1_MASK : uint8_t
-{
-	FDC_SSB1M_ANF = 0x1,
-	FDC_SSB1M_WPM = 0x2,
-	FDC_SSB1M_INF = 0x4,
-	FDC_SSB1M_DOR = 0x10,
-	FDC_SSB1M_CER = 0x20,
-	FDC_SSB1M_NDE = 0x80,
-};
-
-hd63266f_device_t::hd63266f_device_t(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
-	: device_t(mconfig, HD63266F, tag, owner, clock),
-	irq_cb(*this),
-	dreq_cb(*this),
-	dend_cb(*this)
-{
-}
-
-void hd63266f_device_t::device_start()
-{
-	irq_cb.resolve();
-	dreq_cb.resolve();
-	dend_cb.resolve();
-	assert(!dreq_cb.isnull() && "only DMA mode supported; supply a DREQ_W callback!");
-	assert(!dend_cb.isnull() && "only DMA mode supported; supply a DEND_R callback!");
-}
-
-void hd63266f_device_t::reset()
-{
-	str = FDC_STATUSM_TXR;
-	cmd = 0x00;
-	parameter_cnt = 0;
-	dma_cnt = 0;
-	hsl_us = ca = ha = sa = rl = esn = gsl = mnl = 0;
-	scnt = gp3l = dud = 0;
-	ncn = 0;
-	step = 0;
-	str_hdut = 0; hdlt_ndm = 0;
-	lctk = pc1_pc0 = pcdct = 0;
-	ssb0 = ssb1 = ssb2 = ssb3 = 0;
-	pcn = 0;
-}
-
-void hd63266f_device_t::write(uint8_t data)
-{
-	bool input_done = false;
-	auto oldSTR = str;
-
-	if(dma_cnt) {
-		auto length = floppy && floppy->is_open() ? floppy->length() : 0;
-		auto buffer = static_cast<uint8_t*>(floppy && floppy->is_open() ? floppy->image.get() : nullptr);
-
-		if(buffer && dma_src < length) {
-			switch(cmd & 0x1f) {
-			case FDC_COMMAND_WRITE_DATA:
-			case FDC_COMMAND_WRITE_DELETED_DATA:
-				dma_cnt--;
-				if(dend_cb()) {
-					logerror("fdc: ~TEND0 asserted; stopping DMA; DMA_cnt=%04x %s\n", dma_cnt, machine().describe_context());
-					dma_cnt = 0;
-				}
-				logerror("fdc: read DMA; DMA_cnt=%04x DMA_src=%08x %s\n", dma_cnt, dma_src, machine().describe_context());
-				if(dma_cnt == 0) {
-					// indicate result is ready
-					str = FDC_STATUSM_TXR | FDC_STATUSM_DIR | FDC_STATUSM_BSY;
-					if(!irq_cb.isnull()) irq_cb(true);
-				} else {
-					// notify DMA to write the next byte
-					dreq_cb(true);
-				}
-				buffer[dma_src++] = data;
-				floppy->dirty = true;
-				break;
-			default:
-				logerror("fdc: DMA active for unknown command %s\n", machine().describe_context());
-				break;
-			}
-		} else {
-			logerror("fdc: DMA out of range of floppy image %s\n", machine().describe_context());
-			return;
-		}
-	} else {
-		if(!(str & FDC_STATUSM_BSY)) {
-			// write command code
-			cmd = data;
-			str |= FDC_STATUSM_BSY;
-			str &= ~FDC_STATUSM_TXR;
-
-			switch(cmd & 0x1f) {
-			case FDC_COMMAND_CHECK_INTERRUPT_STATUS:
-			case FDC_COMMAND_SLEEP:
-			case FDC_COMMAND_ABORT:
-				input_done = true;
-				break;
-			default:
-				// ready to receive command parameters
-				parameter_cnt = 0;
-				str |= FDC_STATUSM_TXR;
-				break;
-			}
-			logerror("fdc:write_cmd(%02x) STR=%02x => %02x %s\n", data, oldSTR, str, machine().describe_context());
-		} else {
-			// write command parameter
-			switch(cmd & 0x1f) {
-			case FDC_COMMAND_READ_DATA:
-			case FDC_COMMAND_READ_DELETED_DATA:
-			case FDC_COMMAND_READ_ERRONEOUS_DATA:
-			case FDC_COMMAND_WRITE_DATA:
-			case FDC_COMMAND_WRITE_DELETED_DATA:
-			case FDC_COMMAND_READ_LONG:
-			case FDC_COMMAND_WRITE_LONG:
-				switch(parameter_cnt) {
-				case 0: hsl_us = data; break;
-				case 1: ca = data; break;
-				case 2: ha = data; break;
-				case 3: sa = data; break;
-				case 4: rl = data; break;
-				case 5: esn = data; break;
-				case 6: gsl = data; break;
-				case 7: mnl = data; input_done = true; break;
-				default: logerror("%s: no more parameters\n", machine().describe_context());
-				}
-				break;
-			case FDC_COMMAND_READ_ID:
-			case FDC_COMMAND_RECALIBRATE:
-			case FDC_COMMAND_CHECK_DEVICE_STATUS:
-				switch(parameter_cnt) {
-				case 0: hsl_us = data; input_done = true; break;
-				default: logerror("%s: no more parameters\n", machine().describe_context());
-				}
-				break;
-			case FDC_COMMAND_WRITE_FORMAT:
-				switch(parameter_cnt) {
-				case 0: hsl_us = data; break;
-				case 1: rl = data; break;
-				case 2: scnt = data; break;
-				case 3: gp3l = data; break;
-				case 4: dud = data; input_done = true; break;
-				default: logerror("%s: no more parameters\n", machine().describe_context());
-				}
-				break;
-			case FDC_COMMAND_SEEK:
-				switch(parameter_cnt) {
-				case 0: hsl_us = data; break;
-				case 1: ncn = data; input_done = true; break;
-				default: logerror("%s: no more parameters\n", machine().describe_context());
-				}
-				break;
-			case FDC_COMMAND_COMPARE_EQUAL:
-			case FDC_COMMAND_COMPARE_LOW_OR_EQUAL:
-			case FDC_COMMAND_COMPARE_HIGH_OR_EQUAL:
-				switch(parameter_cnt) {
-				case 0: hsl_us = data; break;
-				case 1: ca = data; break;
-				case 2: ha = data; break;
-				case 3: sa = data; break;
-				case 4: rl = data; break;
-				case 5: esn = data; break;
-				case 6: gsl = data; break;
-				case 7: step = data; input_done = true; break;
-				default: logerror("%s: no more parameters\n", machine().describe_context());
-				}
-				break;
-			case FDC_COMMAND_CHECK_INTERRUPT_STATUS:
-			case FDC_COMMAND_SLEEP:
-			case FDC_COMMAND_ABORT:
-			default: // INVALID
-				logerror("%s: no more parameters\n", machine().describe_context());
-				break;
-			case FDC_COMMAND_SPECIFY_1:
-				switch(parameter_cnt) {
-				case 0: str_hdut = data; break;
-				case 1: hdlt_ndm = data; input_done = true; break;
-				default: logerror("%s: no more parameters\n", machine().describe_context());
-				}
-				break;
-			case FDC_COMMAND_SPECIFY_2:
-				switch(parameter_cnt) {
-				case 0: str_hdut = data; break;
-				case 1: hdlt_ndm = data; break;
-				case 2: lctk = data; break;
-				case 3: pc1_pc0 = data; break;
-				case 4: pcdct = data; input_done = true; break;
-				default: logerror("%s: no more parameters\n", machine().describe_context());
-				}
-				break;
-			}
-
-			// ready to receive command parameters
-			parameter_cnt++;
-			if(!input_done)
-				str |= FDC_STATUSM_TXR;
-
-			logerror("fdc:write_param(%02x) STR=%02x => %02x %s\n", data, oldSTR, str, machine().describe_context());
-		}
-		if(input_done)
-			execute();
-	}
-}
-
-uint8_t hd63266f_device_t::read()
-{
-	bool output_done = false;
-
-	auto oldSTR = str;
-
-	if(dma_cnt) {
-		auto length = floppy && floppy->is_open() ? floppy->length() : 0;
-		auto buffer = static_cast<uint8_t*>(floppy && floppy->is_open() ? floppy->image.get() : nullptr);
-
-		if(buffer && dma_src < length) {
-			switch(cmd & 0x1f) {
-			case FDC_COMMAND_READ_DATA:
-			case FDC_COMMAND_READ_DELETED_DATA:
-			case FDC_COMMAND_READ_ERRONEOUS_DATA:
-				dma_cnt--;
-				if(dend_cb()) {
-					logerror("fdc: ~TEND0 asserted; stopping DMA; DMA_cnt=%04x %s\n", dma_cnt, machine().describe_context());
-					dma_cnt = 0;
-				}
-				//logerror("fdc: read DMA; DMA_cnt=%04x DMA_src=%08x %s\n", DMA_cnt, DMA_src, machine().describe_context());
-				if(dma_cnt == 0) {
-					// indicate result is ready
-					str = FDC_STATUSM_TXR | FDC_STATUSM_DIR | FDC_STATUSM_BSY;
-					if(!irq_cb.isnull()) irq_cb(true);
-				} else {
-					// notify DMA that next byte is ready
-					dreq_cb(true);
-				}
-				return buffer[dma_src++];
-				break;
-			default:
-				logerror("fdc: DMA active for unknown command %s\n", machine().describe_context());
-				break;
-			}
-		} else {
-			logerror("fdc: DMA out of range of floppy image %s\n", machine().describe_context());
-			return 0;
-		}
-	} else {
-		// read result parameters
-		if((str & (FDC_STATUSM_TXR | FDC_STATUSM_DIR | FDC_STATUSM_BSY)) == (FDC_STATUSM_TXR | FDC_STATUSM_DIR | FDC_STATUSM_BSY)) {
-			switch(cmd & 0x1f) {
-			case FDC_COMMAND_READ_DATA:
-			case FDC_COMMAND_READ_DELETED_DATA:
-			case FDC_COMMAND_READ_ERRONEOUS_DATA:
-			case FDC_COMMAND_READ_ID:
-			case FDC_COMMAND_WRITE_DATA:
-			case FDC_COMMAND_WRITE_DELETED_DATA:
-			case FDC_COMMAND_WRITE_FORMAT:
-			case FDC_COMMAND_COMPARE_EQUAL:
-			case FDC_COMMAND_COMPARE_HIGH_OR_EQUAL:
-			case FDC_COMMAND_COMPARE_LOW_OR_EQUAL:
-			case FDC_COMMAND_READ_LONG:
-			case FDC_COMMAND_WRITE_LONG:
-				switch(parameter_cnt) {
-				case 0: dtr = ssb0; break;
-				case 1: dtr = ssb1; break;
-				case 2: dtr = ssb2; break;
-				case 3: dtr = ca; break;
-				case 4: dtr = ha; break;
-				case 5: dtr = sa; break;
-				case 6: dtr = rl; output_done = true; break;
-				default: logerror("%s: no more parameters\n", machine().describe_context());
-				}
-				break;
-			case FDC_COMMAND_SEEK:
-			case FDC_COMMAND_RECALIBRATE:
-			case FDC_COMMAND_SPECIFY_1:
-			case FDC_COMMAND_SPECIFY_2:
-			case FDC_COMMAND_SLEEP:
-			case FDC_COMMAND_ABORT:
-				logerror("%s: no more parameters\n", machine().describe_context());
-				break;
-			case FDC_COMMAND_CHECK_DEVICE_STATUS:
-			default: // INVALID
-				switch(parameter_cnt) {
-				case 0: dtr = ssb3; output_done = true; break;
-				default: logerror("%s: no more parameters\n", machine().describe_context());
-				}
-				break;
-			case FDC_COMMAND_CHECK_INTERRUPT_STATUS:
-				switch(parameter_cnt) {
-				case 0: dtr = ssb0; break;
-				case 1: dtr = pcn; output_done = true; break;
-				default: logerror("%s: no more parameters\n", machine().describe_context());
-				}
-				break;
-			}
-			parameter_cnt++;
-
-			str &= ~FDC_STATUSM_TXR;
-			str &= ~FDC_STATUSM_DIR;
-			if(!irq_cb.isnull()) irq_cb(false);
-
-			if(output_done) {
-				// enter command waiting state
-				str |= FDC_STATUSM_TXR;
-				str &= ~FDC_STATUSM_BSY;
-			} else {
-				// signal next result parameter is ready
-				str |= FDC_STATUSM_TXR;
-				str |= FDC_STATUSM_DIR;
-			}
-		}
-	}
-
-	logerror("fdc:read STR=%02x => %02x %s\n", oldSTR, str, machine().describe_context());
-
-	return dtr;
-}
-
-void hd63266f_device_t::execute()
-{
-	ssb0 = ssb1 = ssb2 = ssb3 = 0;
-
-	auto oldSTR = str;
-
-	auto readwrite_params = [this] {
-		return string_format("HSL_US=%02x CA=%02x HA=%02x SA=%02x RL=%02x ESN=%02x GSL=%02x MNL=%02x", hsl_us, ca, ha, sa, rl, esn, gsl, mnl);
-	};
-
-	auto length = floppy && floppy->is_open() ? floppy->length() : 0;
-	auto buffer = floppy && floppy->is_open() ? floppy->image.get() : nullptr;
-
-	// do something
-	switch(cmd & 0x1f) {
-	case FDC_COMMAND_READ_DATA: {
-		// 720kb  floppy: 80 cylinders, 2 heads,  9 each 512b sectors per track
-		// 1.44mb floppy: 80 cylinders, 2 heads, 18 each 512b sectors per track
-		auto sector_length = 128 << (rl & 0b111);
-		auto sectors_per_track = (str_hdut >> 4) == 0xa ? 18 : 9; // detect 1.44mb/720kb mode; based on LW-350 code
-		dma_src = (((ca << 1) | (ha & 1)) * sectors_per_track + sa - 1) * sector_length;
-		dma_cnt = (esn - sa - 1 + 1) * sector_length;
-		str = FDC_STATUSM_TXR | FDC_STATUSM_DIR | FDC_STATUSM_BSY;
-		dreq_cb(true);
-		logerror("%s: fdc: execute: READ DATA; %s DMA_cnt=%04x DMC_src=%08x\n", machine().describe_context(), readwrite_params(), dma_cnt, dma_src);
-		break;
-	}
-	case FDC_COMMAND_READ_DELETED_DATA:
-		logerror("%s: fdc: execute: READ DELETED DATA; %s\n", machine().describe_context(), readwrite_params());
-		break;
-	case FDC_COMMAND_READ_ERRONEOUS_DATA:
-		logerror("%s: fdc: execute: READ ERRONEOUS DATA; %s\n", machine().describe_context(), readwrite_params());
-		break;
-	case FDC_COMMAND_READ_ID:
-		logerror("%s: fdc: execute: READ ID\n", machine().describe_context());
-		break;
-	case FDC_COMMAND_WRITE_DATA: {
-		auto sector_length = 128 << (rl & 0b111);
-		auto sectors_per_track = (str_hdut >> 4) == 0xa ? 18 : 9; // detect 1.44mb/720kb mode; based on LW-350 code
-		dma_src = (((ca << 1) | (ha & 1)) * sectors_per_track + sa - 1) * sector_length;
-		dma_cnt = (esn - sa - 1 + 1) * sector_length;
-		str = FDC_STATUSM_TXR | FDC_STATUSM_BSY;
-		dreq_cb(true);
-		logerror("%s: fdc: execute: WRITE DATA; %s DMA_cnt=%04x DMC_src=%08x\n", machine().describe_context(), readwrite_params(), dma_cnt, dma_src);
-		break;
-	}
-	case FDC_COMMAND_WRITE_DELETED_DATA:
-		logerror("%s: fdc: execute: WRITE DELETED DATA; %s\n", machine().describe_context(), readwrite_params());
-		break;
-	case FDC_COMMAND_WRITE_FORMAT: {
-		auto sector_length = 128 << (rl & 0b111);
-		auto sectors_per_track = (str_hdut >> 4) == 0xa ? 18 : 9; // detect 1.44mb/720kb mode; based on LW-350 code
-		auto dst = ((pcn << 1) | ((hsl_us & 0b100) >> 2)) * sectors_per_track * sector_length;
-		auto cnt = scnt * sector_length >> 1; // not sure why >> 1, but matches how it's called
-		logerror("%s: fdc: execute: WRITE FORMAT; HSL_US=%02x PCN=%02x SCNT=%02x RL=%02x DUD=%02x cnt=%04x ofs=%08x\n", machine().describe_context(), hsl_us, pcn, scnt, rl, dud, cnt, dst);
-		while(cnt--) {
-			if(dst < length)
-				buffer[dst++] = dud;
-		}
-		break;
-	}
-	case FDC_COMMAND_SEEK:
-		logerror("%s: fdc: execute: SEEK NCN=%d\n", machine().describe_context(), ncn);
-		ssb0 |= FDC_SSB0M_SED;
-		pcn = ncn;
-		if(ncn == 0)
-			ssb3 |= FDC_SSB3M_TRZ;
-		else
-			ssb3 &= ~FDC_SSB3M_TRZ;
-		break;
-	case FDC_COMMAND_RECALIBRATE:
-		logerror("%s: fdc: execute: RECALIBRATE\n", machine().describe_context());
-		ssb0 |= FDC_SSB0M_SED;
-		ssb3 |= FDC_SSB3M_TRZ;
-		pcn = 0;
-		break;
-	case FDC_COMMAND_COMPARE_EQUAL:
-		logerror("%s: fdc: execute: COMPARE EQUAL\n", machine().describe_context());
-		break;
-	case FDC_COMMAND_COMPARE_LOW_OR_EQUAL:
-		logerror("%s: fdc: execute: COMPARE LOW OR EQUAL\n", machine().describe_context());
-		break;
-	case FDC_COMMAND_COMPARE_HIGH_OR_EQUAL:
-		logerror("%s: fdc: execute: COMPARE HIGH OR EQUAL\n", machine().describe_context());
-		break;
-	case FDC_COMMAND_CHECK_DEVICE_STATUS:
-		logerror("%s: fdc: execute: CHECK DEVICE STATUS\n", machine().describe_context());
-		break;
-	case FDC_COMMAND_CHECK_INTERRUPT_STATUS:
-		logerror("%s: fdc: execute: CHECK INTERRUPT STATUS\n", machine().describe_context());
-		ssb0 &= ~FDC_SSB0M_HSL;
-		break;
-	case FDC_COMMAND_SPECIFY_1:
-		logerror("%s: fdc: execute: SPECIFY 1\n", machine().describe_context());
-		break;
-	case FDC_COMMAND_SPECIFY_2:
-		logerror("%s: fdc: execute: SPECIFY 2\n", machine().describe_context());
-		break;
-	case FDC_COMMAND_SLEEP:
-		logerror("%s: fdc: execute: SLEEP\n", machine().describe_context());
-		break;
-	case FDC_COMMAND_ABORT:
-		logerror("%s: fdc: execute: ABORT\n", machine().describe_context());
-		break;
-	case FDC_COMMAND_READ_LONG:
-		logerror("%s: fdc: execute: READ LONG\n", machine().describe_context());
-		break;
-	case FDC_COMMAND_WRITE_LONG:
-		logerror("%s: fdc: execute: WRITE LONG\n", machine().describe_context());
-		break;
-	}
-
-	ssb0 = FDC_SSB0M_INC_NOR;
-	ssb0 |= hsl_us & 0b11; // mirror US1, US0 from command parameters
-	ssb3 |= hsl_us & 0b111; // mirror HSL, US1, US0 from command parameters
-	if(floppy && floppy->loaded)
-		ssb3 |= FDC_SSB3M_RDY;
-	else {
-		ssb0 |= FDC_SSB0M_DNR;
-		ssb3 &= ~FDC_SSB3M_RDY;
-	}
-
-	parameter_cnt = 0;
-
-	if(!dma_cnt) {
-		switch(cmd & 0x1f) {
-		case FDC_COMMAND_SEEK:
-		case FDC_COMMAND_RECALIBRATE:
-		case FDC_COMMAND_SPECIFY_1:
-		case FDC_COMMAND_SPECIFY_2:
-		case FDC_COMMAND_SLEEP:
-		case FDC_COMMAND_ABORT:
-			// no result
-			str = FDC_STATUSM_TXR;
-			break;
-			//[[fallthrough]]
-			// no IRQ
-		case FDC_COMMAND_CHECK_DEVICE_STATUS:
-		case FDC_COMMAND_CHECK_INTERRUPT_STATUS:
-		default: // INVALID
-			// indicate result is ready
-			str = FDC_STATUSM_TXR | FDC_STATUSM_DIR | FDC_STATUSM_BSY;
-			break;
-		}
-
-		// set IRQ to indicate result is ready
-		switch(cmd & 0x1f) {
-		case FDC_COMMAND_CHECK_DEVICE_STATUS:
-		case FDC_COMMAND_CHECK_INTERRUPT_STATUS:
-			break;
-		default:
-			if(!irq_cb.isnull()) irq_cb(true); // (p.34)
-		   // TODO: not for INVALID
-			break;
-		}
-	}
-
-	logerror("fdc:execute STR=%02x => %02x %s\n", oldSTR, str, machine().describe_context());
-}
-
-void hd63266f_device_t::abort()
-{
-	auto oldSTR = str;
-	reset();
-
-	logerror("fdc:abort STR=%02x => %02x %s\n", oldSTR, str, machine().describe_context());
-}
-
-#else
-
 #include "machine/upd765.h"
-
-
-class hd63266f_device_t : public upd765_family_device {
-public:
-	hd63266f_device_t(const machine_config& mconfig, const char* tag, device_t* owner, uint32_t clock);
-	void map(address_map& map) override {
-		map(0x0, 0x0).r(FUNC(upd765a_device::msr_r));
-		map(0x1, 0x1).rw(FUNC(upd765a_device::fifo_r), FUNC(upd765a_device::fifo_w));
-	}
-
-	auto irq_wr_cb() { return intrq_wr_callback(); }
-	auto dreq_wr_cb() { return drq_wr_callback(); }
-	//auto dend_rd_cb() { return dend_cb.bind(); }
-};
-
-DEFINE_DEVICE_TYPE(HD63266F, hd63266f_device_t, "hd63266f", "Hitachi HD63266F FDC")
-
-hd63266f_device_t::hd63266f_device_t(const machine_config& mconfig, const char* tag, device_t* owner, uint32_t clock)
-: upd765_family_device(mconfig, HD63266F, tag, owner, clock) {
-	set_ready_line_connected(false);
-	set_select_lines_connected(false);
-	has_dor = false;
-}
-
 #include "imagedev/floppy.h"
-
-using lw350_floppy_connector = floppy_connector;
-#define LW350_FLOPPY_CONNECTOR FLOPPY_CONNECTOR
-#define LW350_FLOPPY FLOPPY_35_HD
-
-#endif
 
 class lw350_state : public driver_device
 {
@@ -870,11 +86,12 @@ public:
 		: driver_device(mconfig, type, tag),
 		maincpu(*this, "maincpu"),
 		screen(*this, "screen"),
-		floppy(*this, "floppy"),
+		floppy(*this, "fdc:0"),
 		fdc(*this, "fdc"),
 		beeper(*this, "beeper"),
 		io_kbrow(*this, "kbrow.%u", 0),
-		rombank(*this, "rom")
+		rombank(*this, "rom"),
+		vram(*this, "vram")
 	{ }
 
 	void lw350(machine_config& config);
@@ -889,14 +106,15 @@ private:
 	// devices
 	required_device<hd64180rp_device> maincpu;
 	required_device<screen_device> screen;
-	required_device<lw350_floppy_connector> floppy;
-	required_device<hd63266f_device_t> fdc;
+	required_device<floppy_connector> floppy;
+	required_device<hd63266f_device> fdc;
 	required_device<beep_device> beeper;
 	required_ioport_array<9> io_kbrow;
 	required_memory_bank rombank;
 
-	uint8_t vram[80 * 128];
-	uint8_t io_70, io_7a, io_b8, io_90;
+	required_shared_ptr<u8> vram;
+	uint8_t io_70, io_b8, io_90;
+	int fdc_drq;
 
 	// screen updates
 	uint32_t screen_update(screen_device& screen, bitmap_rgb32& bitmap, const rectangle& cliprect);
@@ -955,39 +173,16 @@ private:
 		maincpu->set_input_line(INPUT_LINE_IRQ1, CLEAR_LINE);
 	}
 
-	// Floppy
-	#ifndef UPD765
-	void fdc_dtr_w(uint8_t data) { // 79
-		fdc->set_floppy(floppy->get_device());
-		fdc->write(data);
-	}
-	#endif
-	uint8_t io_7a_r() { // 7a
-		return io_7a;
-	}
 	uint8_t io_7e_r() {
 		return 0x80; // 1.44mb floppy
 	}
-	void io_7e_w(uint8_t) { // 7e
+	void io_7e_w(uint8_t data) { // 7e
 	}
 	uint8_t io_90_r() { // 90
-		return io_90;
+		return floppy ? (!floppy->get_device()->idx_r()) << 6 : 0;
 	}
 
 	TIMER_DEVICE_CALLBACK_MEMBER(io_90_timer_callback);
-
-	DECLARE_WRITE_LINE_MEMBER(fdc_irq_w) { io_7a &= ~0x40; if(state) io_7a |= 0x40; }
-	DECLARE_WRITE_LINE_MEMBER(fdc_dreq_w) { maincpu->set_input_line(Z180_INPUT_LINE_DREQ0, state ? ASSERT_LINE : CLEAR_LINE); }
-	DECLARE_READ_LINE_MEMBER(fdc_dend_r) { return maincpu->get_tend0(); }
-
-	// VRAM
-	uint8_t vram_r(offs_t offset, uint8_t mem_mask = ~0) {
-		return vram[offset] & mem_mask;
-	}
-	void vram_w(offs_t offset, uint8_t data, uint8_t mem_mask = ~0) {
-		vram[offset] = (vram[offset] & ~mem_mask) | data;
-	}
-
 	TIMER_DEVICE_CALLBACK_MEMBER(int1_timer_callback);
 
 	void map_program(address_map& map) {
@@ -996,7 +191,7 @@ private:
 		map(0x06000, 0x3ffff).rom();
 		map(0x40000, 0x5ffff).bankr("rom");
 		map(0x60000, 0x617ff).ram();
-		map(0x61800, 0x63fff).rw(FUNC(lw350_state::vram_r), FUNC(lw350_state::vram_w));
+		map(0x61800, 0x63fff).ram().share("vram");
 		map(0x64000, 0x71fff).ram();
 		map(0x72000, 0x75fff).rom().region("maincpu", 0x2000); // => ROM 0x02000-0x05fff
 		map(0x76000, 0x7ffff).ram();
@@ -1009,13 +204,10 @@ private:
 		map(0x74, 0x74).r(FUNC(lw350_state::io_74_r));
 
 		// floppy
-		#ifndef UPD765
-			map(0x78, 0x78).rw("fdc", FUNC(hd63266f_device_t::status_r), FUNC(hd63266f_device_t::abort_w));
-			map(0x79, 0x79).r("fdc", FUNC(hd63266f_device_t::data_r)).w(FUNC(lw350_state::fdc_dtr_w));
-		#else
-			map(0x78, 0x79).m(fdc, FUNC(hd63266f_device_t::map));
-		#endif
-		map(0x7a, 0x7a).r(FUNC(lw350_state::io_7a_r));
+		map(0x78, 0x78).rw(fdc, FUNC(upd765a_device::msr_r), FUNC(hd63266f_device::abort_w));
+		map(0x79, 0x79).lrw8([this](){ return (fdc_drq ? fdc->dma_r() : fdc->fifo_r()); }, "fdc_r",
+				[this](u8 data) { fdc_drq ? fdc->dma_w(data) : fdc->fifo_w(data); }, "fdc_w");
+		map(0x7a, 0x7a).r(fdc, FUNC(hd63266f_device::extstat_r));
 		map(0x7e, 0x7e).rw(FUNC(lw350_state::io_7e_r), FUNC(lw350_state::io_7e_w));
 		map(0x90, 0x90).r(FUNC(lw350_state::io_90_r));
 
@@ -1023,6 +215,7 @@ private:
 		map(0xa8, 0xa8).r(FUNC(lw350_state::io_a8_r));
 
 		map(0xb8, 0xb8).rw(FUNC(lw350_state::io_b8_r), FUNC(lw350_state::io_b8_w));
+		map(0xd8, 0xd8).nopw();
 		map(0xe0, 0xe0).w(FUNC(lw350_state::rombank_w));
 		map(0xf0, 0xf0).w(FUNC(lw350_state::beeper_w));
 		map(0xf8, 0xf8).w(FUNC(lw350_state::irqack_w));
@@ -1164,14 +357,6 @@ TIMER_DEVICE_CALLBACK_MEMBER(lw350_state::int1_timer_callback)
 	maincpu->set_input_line(INPUT_LINE_IRQ1, ASSERT_LINE);
 }
 
-TIMER_DEVICE_CALLBACK_MEMBER(lw350_state::io_90_timer_callback)
-{
-	#ifndef UPD765
-	if(floppy && floppy->get_device() && floppy->get_device()->loaded)
-	#endif
-		io_90 ^= 1 << 6; // int1_process_floppy wants this to toggle, 150 ms, HACK
-}
-
 //uint8_t char_attribute = 0x00;
 
 void lw350_state::machine_start()
@@ -1227,22 +412,22 @@ void lw350_state::machine_start()
 void lw350_state::machine_reset()
 {
 	io_90 = 0x00;
-	io_7a = 0x01; // int1_process_floppy waits for bit 0 set
 	fdc->reset();
+	fdc_drq = 0;
 }
 
-#ifdef UPD765
-	static void lw350_floppies(device_slot_interface& device) {
-		device.option_add("35dd", FLOPPY_35_DD);
-		device.option_add("35hd", FLOPPY_35_HD);
-	}
-#endif
+static void lw350_floppies(device_slot_interface& device) {
+	device.option_add("35dd", FLOPPY_35_DD);
+	device.option_add("35hd", FLOPPY_35_HD);
+}
 
 void lw350_state::lw350(machine_config& config) {
 	// basic machine hardware
 	HD64180RP(config, maincpu, 16'000'000 / 2);
 	maincpu->set_addrmap(AS_PROGRAM, &lw350_state::map_program);
 	maincpu->set_addrmap(AS_IO, &lw350_state::map_io);
+	maincpu->tend0_wr_callback().set([this](int state){ fdc->tc_w((fdc_drq && state) ? 1 : 0); });
+	maincpu->rts0_wr_callback().set(fdc, FUNC(hd63266f_device::rate_w));
 	TIMER(config, "1khz").configure_periodic(FUNC(lw350_state::int1_timer_callback), attotime::from_hz(1000));
 
 	// video hardware
@@ -1253,22 +438,13 @@ void lw350_state::lw350(machine_config& config) {
 	screen->set_screen_update(FUNC(lw350_state::screen_update));
 	screen->set_size(480, 128);
 
-	// floppy disk
-	TIMER(config, "io_90").configure_periodic(FUNC(lw350_state::io_90_timer_callback), attotime::from_msec(160));
-	#ifndef UPD765
-		LW350_FLOPPY_CONNECTOR(config, floppy, 0);
-		floppy->option_add("35hd", LW350_FLOPPY);
-		floppy->set_default_option("35hd");
-	#else
-		FLOPPY_CONNECTOR(config, floppy, lw350_floppies, "35hd", floppy_image_device::default_pc_floppy_formats);
-	#endif
-
 	HD63266F(config, fdc, XTAL(16'000'000));
-	fdc->irq_wr_cb().set(FUNC(lw350_state::fdc_irq_w));
-	fdc->dreq_wr_cb().set(FUNC(lw350_state::fdc_dreq_w));
-	#ifndef UPD765
-		fdc->dend_rd_cb().set(FUNC(lw350_state::fdc_dend_r));
-	#endif
+	fdc->drq_wr_callback().set([this](int state){ fdc_drq = state; maincpu->set_input_line(Z180_INPUT_LINE_DREQ0, state); });
+	fdc->set_ready_line_connected(false);
+	fdc->set_select_lines_connected(false);
+	fdc->inp_rd_callback().set([this](){ return floppy->get_device()->dskchg_r(); });
+
+	FLOPPY_CONNECTOR(config, floppy, lw350_floppies, "35hd", floppy_image_device::default_pc_floppy_formats);
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();
@@ -1388,7 +564,7 @@ public:
 		maincpu(*this, "maincpu"),
 		screen(*this, "screen"),
 		palette(*this, "palette"),
-		floppy(*this, "floppy"),
+		floppy(*this, "fdc:0"),
 		fdc(*this, "fdc"),
 		m_crtc(*this, "hd6445"),
 		vram(*this, "vram"),
@@ -1411,8 +587,8 @@ private:
 	required_device<z80180_device> maincpu; // use z80180 instead of hd64180rp, because hd64180rf doesn't have hd64180rp's 19-bit address width
 	required_device<screen_device> screen;
 	required_device<palette_device> palette;
-	required_device<lw350_floppy_connector> floppy;
-	required_device<hd63266f_device_t> fdc;
+	required_device<floppy_connector> floppy;
+	required_device<hd63266f_device> fdc;
 	required_device<hd6345_device> m_crtc;
 	required_shared_ptr<uint8_t> vram;
 	required_device<beep_device> speaker;
@@ -1421,7 +597,7 @@ private:
 	required_memory_bank rombank;
 
 	uint8_t io_72, io_73, io_74, io_75; // gfx
-	uint8_t io_7a, io_b8;
+	uint8_t io_b8;
 	uint32_t framecnt;
 
 	uint8_t illegal_r(offs_t offset) {
@@ -1459,20 +635,6 @@ private:
 	void irqack_w(uint8_t) { // F8
 		maincpu->set_input_line(INPUT_LINE_IRQ1, CLEAR_LINE);
 	}
-
-	// Floppy
-	#ifndef UPD765
-	void fdc_dtr_w(uint8_t data) { // 79
-		fdc->set_floppy(floppy->get_device());
-		fdc->write(data);
-	}
-	#endif
-	uint8_t io_7a_r() { // 7a
-		return io_7a;
-	}
-	DECLARE_WRITE_LINE_MEMBER(fdc_irq_w) { io_7a &= ~0x40; if(state) io_7a |= 0x40; }
-	DECLARE_WRITE_LINE_MEMBER(fdc_dreq_w) { maincpu->set_input_line(Z180_INPUT_LINE_DREQ0, state ? ASSERT_LINE : CLEAR_LINE); }
-	DECLARE_READ_LINE_MEMBER(fdc_dend_r) { return maincpu->get_tend0(); }
 
 	// CRTC
 	MC6845_UPDATE_ROW(crtc_update_row);
@@ -1519,13 +681,7 @@ void lw450_state::map_io(address_map& map)
 	map(0x75, 0x75).w(FUNC(lw450_state::io_75_w));
 
 	// floppy
-	#ifndef UPD765
-		map(0x78, 0x78).rw("fdc", FUNC(hd63266f_device_t::status_r), FUNC(hd63266f_device_t::abort_w));
-		map(0x79, 0x79).r("fdc", FUNC(hd63266f_device_t::data_r)).w(FUNC(lw450_state::fdc_dtr_w));
-	#else
-		map(0x78, 0x79).m(fdc, FUNC(hd63266f_device_t::map));
-	#endif
-	map(0x7a, 0x7a).r(FUNC(lw450_state::io_7a_r));
+	map(0x78, 0x7a).m(fdc, FUNC(hd63266f_device::map));
 
 	map(0xb0, 0xb0).r(FUNC(lw450_state::io_b0_r));
 	map(0xb8, 0xb8).rw(FUNC(lw450_state::io_b8_r), FUNC(lw450_state::io_b8_w));
@@ -1698,6 +854,7 @@ void lw450_state::lw450(machine_config& config) {
 	Z80180(config, maincpu, 12'000'000 / 2);
 	maincpu->set_addrmap(AS_PROGRAM, &lw450_state::map_program);
 	maincpu->set_addrmap(AS_IO, &lw450_state::map_io);
+	maincpu->tend0_wr_callback().set(fdc, FUNC(hd63266f_device::tc_line_w));
 	TIMER(config, "1khz").configure_periodic(FUNC(lw450_state::int1_timer_callback), attotime::from_hz(1000));
 
 	// video hardware
@@ -1718,16 +875,12 @@ void lw450_state::lw450(machine_config& config) {
 	m_crtc->set_update_row_callback(FUNC(lw450_state::crtc_update_row));
 	m_crtc->out_vsync_callback().set(FUNC(lw450_state::crtc_vsync));
 
-	LW350_FLOPPY_CONNECTOR(config, floppy, 0);
-	floppy->option_add("35dd", LW350_FLOPPY);
-	floppy->set_default_option("35dd");
-
 	HD63266F(config, fdc, XTAL(16'000'000));
-	fdc->irq_wr_cb().set(FUNC(lw450_state::fdc_irq_w));
-	fdc->dreq_wr_cb().set(FUNC(lw450_state::fdc_dreq_w));
-	#ifndef UPD765
-	fdc->dend_rd_cb().set(FUNC(lw450_state::fdc_dend_r));
-	#endif
+	fdc->drq_wr_callback().set_inputline(maincpu, Z180_INPUT_LINE_DREQ0);
+	fdc->set_ready_line_connected(false);
+	fdc->set_select_lines_connected(false);
+
+	FLOPPY_CONNECTOR(config, floppy, lw350_floppies, "35hd", floppy_image_device::default_pc_floppy_formats);
 
 	// sound hardware
 	SPEAKER(config, "mono").front_center();


### PR DESCRIPTION
This removes the bespoke fdc emulation and uses mame's upd765 instead.  The docs for the fdc are sparse so I'm very uncertain about the motor control but I'm fairly confident of the strange use of the two side signal which appears to be a generic input that can be read with sense drive status.